### PR TITLE
Fix boolean safe cast error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Project exclude paths
 /tests/notes_out/
+**/__pycache__

--- a/ctakes_parser/ctakes_parser.py
+++ b/ctakes_parser/ctakes_parser.py
@@ -13,7 +13,10 @@ from ctakes_parser import helpers
 
 def _safe_cast(cast, val):
     if val is not None:
-        val = cast(val)
+        if cast is bool:
+            val = True if val.lower() == "true" else False
+        else:
+            val = cast(val)
     return val
 
 


### PR DESCRIPTION
Hello,

Nice work with this package. I just noticed that everything in the "generic" output column was true even though all my values were actually "false". I fixed it in my fork. Casting any non-empty string to a bool (including"false") returns True so you can't rely on the boolean cast to do what you want. 