### PR TITLE
Added code attribute for each instance of codingScheme.  Needed for ICD10 dictionary application. 

### DIFF
--- a/ctakes_parser/ctakes_parser.py
+++ b/ctakes_parser/ctakes_parser.py
@@ -92,6 +92,7 @@ def parse_file(file_path) -> pd.DataFrame:
             id = _safe_cast(int, child.get('{http://www.omg.org/XMI}id', None))
             tui = child.get('tui', None)
             score = _safe_cast(float, child.get('score', None))
+            code = child.get('code', None)
 
             results.update_val_at(id, 'refsem', name)
             results.update_val_at(id, 'cui', cui)
@@ -99,6 +100,7 @@ def parse_file(file_path) -> pd.DataFrame:
             results.update_val_at(id, 'scheme', scheme)
             results.update_val_at(id, 'tui', tui)
             results.update_val_at(id, 'score', score)
+            results.update_val_at(id, 'code', code)
 
         if 'http:///org/apache/ctakes/typesystem/type/syntax.ecore' in namespace_keys:
             name = etree.QName(child.tag).localname

--- a/ctakes_parser/helpers.py
+++ b/ctakes_parser/helpers.py
@@ -33,7 +33,7 @@ class ResultDataframeModule(BaseDataframeModule):
         self._index = defaultdict(list)
 
     def insert(self, textsem=None, refsem=None, id=None, pos_start=None, pos_end=None, cui=None, negated=None,
-               preferred_text=None, scheme=None, tui=None, score=None, confidence=None, uncertainty=None,
+               preferred_text=None, scheme=None, code=None, tui=None, score=None, confidence=None, uncertainty=None,
                conditional=None, generic=None, subject=None):
 
         for k, v in locals().items():


### PR DESCRIPTION
Current implementation lacks the codes (SNOMED or ICD9, 10 etc) extracted by the cTAKES Clinical Pipeline runner.  Codes are needed, if you desire to feed ICD-10 codes to a DRG grouper application. 